### PR TITLE
Prevent fatal errors when body undefined

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -46,7 +46,7 @@ class Client {
 
     request(options, (err, resp, body) => {
       if (!err && resp.statusCode >= 400) {
-        err = new ClarifyCodyError(body.message, body);
+        err = new ClarifyCodyError((body && body.message) || 'Internal server error', body);
       }
       callback(err, body);
     });


### PR DESCRIPTION
Some kind of errors does not return a body, if the body is undefined the could will result on an fatal error. 